### PR TITLE
Fixed sqlite3 "too many SQL variables" error.

### DIFF
--- a/dejavu/__init__.py
+++ b/dejavu/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import binascii
-import dejavu.decoder as decoder
+from . import decoder
 from . import fingerprint
 import logging
 import multiprocessing

--- a/dejavu/database.py
+++ b/dejavu/database.py
@@ -132,11 +132,14 @@ class Database(object):
 
         # Get an iterable of all the hashes we need
         values = [h for h in mapper.keys()]
-
-        for fingerprint in self.session.query(Fingerprint).filter(
-            Fingerprint.hash.in_(values)
-        ):
-            yield (fingerprint.song_id, fingerprint.offset - mapper[fingerprint.hash])
+        
+        for i in range(0, len(values), 500):
+            k = i + 500
+            tmp = values[i:k]
+            for fingerprint in self.session.query(Fingerprint).filter(
+                    Fingerprint.hash.in_(tmp)
+                    ):
+                yield (fingerprint.song_id, fingerprint.offset - mapper[fingerprint.hash])
 
     @retry(wait=wait_fixed(1),stop=stop_after_attempt(10))
     def __is_db_ready__(self, url):


### PR DESCRIPTION
sqlite3 has a limit that causes an error when recognizing files that have more than 1k fingerprints.  Fixed by querying the database in chunks of 500.